### PR TITLE
add switch enable_fastalign to [engine] config, to make it possible to load quicker for translation only without fast_align

### DIFF
--- a/scripts/engine.py
+++ b/scripts/engine.py
@@ -320,6 +320,7 @@ class MMTEngine:
         'lm_type': ('LM implementation', (basestring, LanguageModel.available_types), 'MultiplexedLM'),
         'aligner_type': ('Aligner implementation',
                          (basestring, WordAligner.available_types), WordAligner.available_types[0]),
+        'enable_fastalign': ('Enable fast_align loading at startup (provides word alignment API)', bool, True)
     }
 
     training_steps = ['tm_cleanup', 'preprocess', 'context_analyzer', 'lm', 'tm']
@@ -331,6 +332,7 @@ class MMTEngine:
 
         self._lm_type = None  # Injected
         self._aligner_type = None  # Injected
+        self._enable_fastalign = None  # Injected
 
         self._config = None
 
@@ -395,6 +397,8 @@ class MMTEngine:
             self._config = injector.to_config()
             self._config.set(self.injector_section, 'source_lang', self.source_lang)
             self._config.set(self.injector_section, 'target_lang', self.target_lang)
+
+            self._config.set(self.injector_section, 'enable_fastalign', str(self._enable_fastalign).lower())
 
     @property
     def config(self):

--- a/src/Core/src/main/java/eu/modernmt/engine/SlaveNode.java
+++ b/src/Core/src/main/java/eu/modernmt/engine/SlaveNode.java
@@ -86,7 +86,7 @@ public class SlaveNode extends Worker {
     private void loadAligner() throws IOException {
         if (aligner == null) {
             synchronized (this) {
-                if (aligner == null) {
+                if (aligner == null && engine.isEnableFastalign()) {
                     aligner = new SymmetrizedAligner(this.engine.getPath().getAbsolutePath());
                     try {
                         aligner.init();

--- a/src/Core/src/main/java/eu/modernmt/engine/TranslationEngine.java
+++ b/src/Core/src/main/java/eu/modernmt/engine/TranslationEngine.java
@@ -97,6 +97,10 @@ public class TranslationEngine {
         return getConfig().getDecoderWeights();
     }
 
+    public boolean isEnableFastalign() {
+        return getConfig().isEnableFastalign();
+    }
+
     public void setDecoderWeights(Map<String, float[]> weights) {
         TranslationEngineConfig config = getConfig();
         config.setDecoderWeights(weights);

--- a/src/Core/src/main/java/eu/modernmt/engine/TranslationEngineConfig.java
+++ b/src/Core/src/main/java/eu/modernmt/engine/TranslationEngineConfig.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 /**
  * Created by davide on 21/12/15.
@@ -39,6 +40,16 @@ public class TranslationEngineConfig {
 
     private TranslationEngineConfig(HierarchicalINIConfiguration config) {
         this.config = config;
+    }
+
+    public boolean isEnableFastalign() {
+        SubnodeConfiguration section = config.configurationAt("engine");
+        try {
+            return section.getBoolean("enable_fastalign");
+        } catch (NoSuchElementException e) {
+            // for legacy configurations which lack this entry in [engine]
+            return true;
+        }
     }
 
     public Locale getSourceLanguage() {


### PR DESCRIPTION
I know this is only a development-only "feature", but do you think this is reasonable to merge?