### PR TITLE
Perfect memory match on sub-segments

### DIFF
--- a/src/core/src/main/java/eu/modernmt/facade/TranslationFacade.java
+++ b/src/core/src/main/java/eu/modernmt/facade/TranslationFacade.java
@@ -369,29 +369,30 @@ public class TranslationFacade {
             }
         }
 
-        private Translation[] translate(Sentence[] sentences, Decoder decoder, Engine engine) throws DecoderException, AlignerException {
-            Translation[] translations = new Translation[sentences.length];
+		private Translation[] translate(Sentence[] sentences, Decoder decoder, Engine engine)
+				throws DecoderException, AlignerException {
+			Translation[] translations = new Translation[sentences.length];
 
 			for (int i = 0; i < sentences.length; i++) {
 				Translation translation = this.translate(sentences[i], decoder);
 				// Alignment
 				if (!translation.hasAlignment()) {
-                    Aligner aligner = engine.getAligner();
+					Aligner aligner = engine.getAligner();
 
-                    Alignment alignment = aligner.getAlignment(direction, sentences[i], translation);
-                    translation.setWordAlignment(alignment);
+					Alignment alignment = aligner.getAlignment(direction, sentences[i], translation);
+					translation.setWordAlignment(alignment);
 
-                    if (translation.hasNbest()) {
-                        for (Translation nbest : translation.getNbest()) {
-                            Alignment nbestAlignment = aligner.getAlignment(direction, sentences[i], nbest);
-                            nbest.setWordAlignment(nbestAlignment);
-                        }
-                    }
-                }
+					if (translation.hasNbest()) {
+						for (Translation nbest : translation.getNbest()) {
+							Alignment nbestAlignment = aligner.getAlignment(direction, sentences[i], nbest);
+							nbest.setWordAlignment(nbestAlignment);
+						}
+					}
+				}
 				translations[i] = translation;
 			}
-            return translations;
-        }
+			return translations;
+		}
 
         private Translation translate(Sentence sentence, Decoder decoder) throws DecoderException {
             Translation translation;

--- a/src/core/src/main/java/eu/modernmt/facade/TranslationFacade.java
+++ b/src/core/src/main/java/eu/modernmt/facade/TranslationFacade.java
@@ -376,10 +376,18 @@ public class TranslationFacade {
 				Translation translation = this.translate(sentences[i], decoder);
 				// Alignment
 				if (!translation.hasAlignment()) {
-					Aligner aligner = engine.getAligner();
-					Alignment alignment = aligner.getAlignment(direction, sentences[i], translation);
-					translation.setWordAlignment(alignment);
-				}
+                    Aligner aligner = engine.getAligner();
+
+                    Alignment alignment = aligner.getAlignment(direction, sentences[i], translation);
+                    translation.setWordAlignment(alignment);
+
+                    if (translation.hasNbest()) {
+                        for (Translation nbest : translation.getNbest()) {
+                            Alignment nbestAlignment = aligner.getAlignment(direction, sentences[i], nbest);
+                            nbest.setWordAlignment(nbestAlignment);
+                        }
+                    }
+                }
 				translations[i] = translation;
 			}
             return translations;

--- a/src/core/src/main/java/eu/modernmt/facade/TranslationFacade.java
+++ b/src/core/src/main/java/eu/modernmt/facade/TranslationFacade.java
@@ -312,7 +312,7 @@ public class TranslationFacade {
 
                 if (decoder.supportsSentenceSplit()) {
                     Sentence[] sentencePieces = SentenceSplitter.forLanguage(direction.source).split(sentence);
-                    Translation[] translationPieces = translate(sentencePieces, decoder);
+                    Translation[] translationPieces = translate(sentencePieces, decoder, engine);
 
                     translation = this.merge(sentence, sentencePieces, translationPieces);
                 } else {
@@ -369,12 +369,19 @@ public class TranslationFacade {
             }
         }
 
-        private Translation[] translate(Sentence[] sentences, Decoder decoder) throws DecoderException {
+        private Translation[] translate(Sentence[] sentences, Decoder decoder, Engine engine) throws DecoderException, AlignerException {
             Translation[] translations = new Translation[sentences.length];
 
-            for (int i = 0; i < sentences.length; i++)
-                translations[i] = this.translate(sentences[i], decoder);
-
+			for (int i = 0; i < sentences.length; i++) {
+				Translation translation = this.translate(sentences[i], decoder);
+				// Alignment
+				if (!translation.hasAlignment()) {
+					Aligner aligner = engine.getAligner();
+					Alignment alignment = aligner.getAlignment(direction, sentences[i], translation);
+					translation.setWordAlignment(alignment);
+				}
+				translations[i] = translation;
+			}
             return translations;
         }
 


### PR DESCRIPTION
If a segment is split into multiple segments and one of them has a perfect match then it results in a NullPointerException (https://github.com/ModernMT/MMT/issues/368). It has to do with the fact that the perfect matched segment will not have the alignment when it tries to merge them. 